### PR TITLE
Update name to Tracklib2 and build on install

### DIFF
--- a/ruby_tracklib2/Rakefile
+++ b/ruby_tracklib2/Rakefile
@@ -14,5 +14,5 @@ RSpec::Core::RakeTask.new(spec: [:bundle_install, :build_lib]) do |t|
   t.pattern = "spec/**/*_spec.rb"
 end
 
-task :default => :spec
+task :default => :build_lib
 task :test => :spec

--- a/ruby_tracklib2/lib/tracklib/version.rb
+++ b/ruby_tracklib2/lib/tracklib/version.rb
@@ -1,3 +1,3 @@
-module Tracklib
+module Tracklib2
   VERSION = "0.1.0"
 end

--- a/ruby_tracklib2/src/lib.rs
+++ b/ruby_tracklib2/src/lib.rs
@@ -6,7 +6,7 @@ use rutie::{Module, Object};
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn Init_Tracklib() {
-    Module::from_existing("Tracklib").define(|module| {
+    Module::from_existing("Tracklib2").define(|module| {
         module.define_nested_class("TrackReader", None).define(|class| {
             class.def_self("new", read::trackreader_new);
             class.def("metadata", read::trackreader_metadata);

--- a/ruby_tracklib2/tracklib.gemspec
+++ b/ruby_tracklib2/tracklib.gemspec
@@ -1,8 +1,8 @@
 require_relative 'lib/tracklib/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "tracklib"
-  spec.version       = Tracklib::VERSION
+  spec.name          = "tracklib2"
+  spec.version       = Tracklib2::VERSION
   spec.authors       = ["Dan Larkin"]
   spec.email         = ["dan@danlarkin.org"]
 
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
   spec.require_paths = ["lib"]
+  spec.extensions = ["Rakefile"]
 
   spec.add_development_dependency "rspec"
 


### PR DESCRIPTION
Changes required for `tracklib` and `tracklib2` to coexist in the rails repo and to have the gem build on install.

```
root@8d5c7e464a83:/app# bundle info tracklib
  * tracklib (0.3.0)
	Summary: tracklib
	Homepage: https://ridewithgps.com
	Path: /usr/local/bundle/gems/tracklib-0.3.0
root@8d5c7e464a83:/app# bundle info tracklib2
  * tracklib2 (0.1.0 621a8c1)
	Summary: tracklib
	Homepage: https://ridewithgps.com
	Path: /usr/local/bundle/bundler/gems/tracklib-621a8c150025/ruby_tracklib2
```