### PR TITLE
Tracklib2 pr2

### DIFF
--- a/ruby_tracklib2/Cargo.toml
+++ b/ruby_tracklib2/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
-name = "ruby_tracklib"
+name = "ruby_tracklib2"
 version = "0.1.0"
 edition = "2021"
 
 [lib]
+name = "ruby_tracklib_version_two"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]

--- a/ruby_tracklib2/Cargo.toml
+++ b/ruby_tracklib2/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "ruby_tracklib2"
+name = "ruby_tracklib_next"
 version = "0.1.0"
 edition = "2021"
 
 [lib]
-name = "ruby_tracklib_version_two"
+name = "ruby_tracklib_next"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]

--- a/ruby_tracklib2/lib/tracklib.rb
+++ b/ruby_tracklib2/lib/tracklib.rb
@@ -1,8 +1,8 @@
 require "tracklib/version"
 require "rutie"
 
-module Tracklib
+module Tracklib2
   unless defined?(TrackReader)
-    Rutie.new(:ruby_tracklib).init 'Init_Tracklib', __dir__
+    Rutie.new(:ruby_tracklib_version_two).init 'Init_Tracklib', __dir__
   end
 end

--- a/ruby_tracklib2/lib/tracklib.rb
+++ b/ruby_tracklib2/lib/tracklib.rb
@@ -1,8 +1,0 @@
-require "tracklib/version"
-require "rutie"
-
-module Tracklib2
-  unless defined?(TrackReader)
-    Rutie.new(:ruby_tracklib_version_two).init 'Init_Tracklib', __dir__
-  end
-end

--- a/ruby_tracklib2/lib/tracklib_next.rb
+++ b/ruby_tracklib2/lib/tracklib_next.rb
@@ -1,0 +1,8 @@
+require "tracklib_next/version"
+require "rutie"
+
+module TracklibNext
+  unless defined?(TrackReader)
+    Rutie.new(:ruby_tracklib_next).init 'Init_Tracklib_Next', __dir__
+  end
+end

--- a/ruby_tracklib2/lib/tracklib_next/version.rb
+++ b/ruby_tracklib2/lib/tracklib_next/version.rb
@@ -1,3 +1,3 @@
-module Tracklib2
+module TracklibNext
   VERSION = "0.1.0"
 end

--- a/ruby_tracklib2/src/lib.rs
+++ b/ruby_tracklib2/src/lib.rs
@@ -5,8 +5,8 @@ use rutie::{Module, Object};
 
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn Init_Tracklib() {
-    Module::from_existing("Tracklib2").define(|module| {
+pub extern "C" fn Init_Tracklib_Next() {
+    Module::from_existing("TracklibNext").define(|module| {
         module.define_nested_class("TrackReader", None).define(|class| {
             class.def_self("new", read::trackreader_new);
             class.def("metadata", read::trackreader_metadata);

--- a/ruby_tracklib2/src/read.rs
+++ b/ruby_tracklib2/src/read.rs
@@ -29,7 +29,7 @@ methods!(
                 .unwrap()
         });
 
-        Module::from_existing("Tracklib")
+        Module::from_existing("TracklibNext")
             .get_nested_class("TrackReader")
             .wrap_data(wrapper, &*TRACK_READER_WRAPPER_INSTANCE)
     },
@@ -297,7 +297,7 @@ impl TrackReader {
 
 impl VerifiedObject for TrackReader {
     fn is_correct_type<T: Object>(object: &T) -> bool {
-        object.class() == Module::from_existing("Tracklib").get_nested_class("TrackReader")
+        object.class() == Module::from_existing("TracklibNext").get_nested_class("TrackReader")
     }
 
     fn error_message() -> &'static str {

--- a/ruby_tracklib2/src/schema.rs
+++ b/ruby_tracklib2/src/schema.rs
@@ -65,7 +65,7 @@ methods!(
             })
             .collect::<Vec<_>>();
 
-        Module::from_existing("Tracklib").get_nested_class("Schema").wrap_data(
+        Module::from_existing("TracklibNext").get_nested_class("Schema").wrap_data(
             WrappableSchema {
                 schema: tracklib2::schema::Schema::with_fields(fields),
             },
@@ -82,7 +82,7 @@ impl Schema {
 
 impl VerifiedObject for Schema {
     fn is_correct_type<T: Object>(object: &T) -> bool {
-        object.class() == Module::from_existing("Tracklib").get_nested_class("Schema")
+        object.class() == Module::from_existing("TracklibNext").get_nested_class("Schema")
     }
 
     fn error_message() -> &'static str {

--- a/ruby_tracklib2/src/write.rs
+++ b/ruby_tracklib2/src/write.rs
@@ -24,7 +24,7 @@ methods!(
         let mut tracklib_section = tracklib2::write::section::standard::Section::new(trimmed_tracklib_schema);
         write_ruby_array_into_section(&mut tracklib_section, ruby_data);
 
-        Module::from_existing("Tracklib").get_nested_class("Section").wrap_data(
+        Module::from_existing("TracklibNext").get_nested_class("Section").wrap_data(
             WrappableSection {
                 section: tracklib2::write::section::Section::Standard(tracklib_section),
             },
@@ -44,7 +44,7 @@ methods!(
                 .unwrap();
         write_ruby_array_into_section(&mut tracklib_section, ruby_data);
 
-        Module::from_existing("Tracklib").get_nested_class("Section").wrap_data(
+        Module::from_existing("TracklibNext").get_nested_class("Section").wrap_data(
             WrappableSection {
                 section: tracklib2::write::section::Section::Encrypted(tracklib_section),
             },
@@ -271,7 +271,7 @@ fn write_ruby_array_into_section<SW: SectionWrite>(section: &mut SW, data: Array
 
 impl VerifiedObject for Section {
     fn is_correct_type<T: Object>(object: &T) -> bool {
-        object.class() == Module::from_existing("Tracklib").get_nested_class("Section")
+        object.class() == Module::from_existing("TracklibNext").get_nested_class("Section")
     }
 
     fn error_message() -> &'static str {
@@ -290,10 +290,10 @@ impl VerifiedObject for Time {
     }
 }
 
-module!(Tracklib);
+module!(TracklibNext);
 
 methods!(
-    Tracklib,
+    TracklibNext,
     rtself,
     fn write_track(metadata: Array, sections: Array) -> RString {
         let metadata_array = metadata.map_err(VM::raise_ex).unwrap();

--- a/ruby_tracklib2/tracklib.gemspec
+++ b/ruby_tracklib2/tracklib.gemspec
@@ -1,7 +1,7 @@
 require_relative 'lib/tracklib/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "tracklib2"
+  spec.name          = "tracklib_next"
   spec.version       = Tracklib2::VERSION
   spec.authors       = ["Dan Larkin"]
   spec.email         = ["dan@danlarkin.org"]

--- a/ruby_tracklib2/tracklib_next.gemspec
+++ b/ruby_tracklib2/tracklib_next.gemspec
@@ -1,20 +1,20 @@
-require_relative 'lib/tracklib/version'
+require_relative 'lib/tracklib_next/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "tracklib_next"
-  spec.version       = Tracklib2::VERSION
+  spec.version       = TracklibNext::VERSION
   spec.authors       = ["Dan Larkin"]
   spec.email         = ["dan@danlarkin.org"]
 
-  spec.summary       = "tracklib"
+  spec.summary       = "tracklib_next"
   spec.description   = "RWGPS tracklib ruby gem"
   spec.homepage      = "https://ridewithgps.com"
   spec.licenses      = ["Apache-2.0", "MIT"]
-  spec.files         = ["tracklib.gemspec",
+  spec.files         = ["tracklib_next.gemspec",
                         "Rakefile",
                         "Gemfile",
-                        "lib/tracklib.rb",
-                        "lib/tracklib/version.rb",
+                        "lib/tracklib_next.rb",
+                        "lib/tracklib_next/version.rb",
                         "Cargo.toml",
                         "Cargo.lock"]
   spec.files        += Dir["src/**/*.rs"]


### PR DESCRIPTION
This should be it for the renames, tested locally, rails can load both gems:

```
rb(main):001:0> TracklibSurfaceMapping
=> TracklibSurfaceMapping
irb(main):002:0> TracklibNext
=> TracklibNext
irb(main):003:0> TracklibNext::Schema
=> TracklibNext::Schema
irb(main):004:0> TracklibNext::TrackReader
=> TracklibNext::TrackReader
irb(main):005:0> TracklibNext::Section
=> TracklibNext::Section
```