### PR TITLE
Tracklib2 Updates

### DIFF
--- a/ruby_tracklib/Gemfile.lock
+++ b/ruby_tracklib/Gemfile.lock
@@ -1,13 +1,14 @@
 PATH
   remote: .
   specs:
-    tracklib (0.1.0)
+    tracklib (2.0.0)
       rutie (~> 0.0.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.4.4)
+    rake (13.0.6)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -27,8 +28,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  rake
   rspec
   tracklib!
 
 BUNDLED WITH
-   2.1.4
+   2.4.15

--- a/ruby_tracklib/default.nix
+++ b/ruby_tracklib/default.nix
@@ -3,10 +3,11 @@ stdenv.mkDerivation rec {
   name = "tracklib";
   env = buildEnv { name = name; paths = buildInputs; };
   buildInputs = [
-    ruby_2_7
+    ruby_3_1
   ];
   shellHook = ''
     mkdir -p .nix-gems
+    export IRBRC=irbrc.rb
     export GEM_HOME=$PWD/.nix-gems
     export GEM_PATH=$GEM_HOME
     export PATH=$GEM_HOME/bin:$PATH

--- a/ruby_tracklib/irbrc.rb
+++ b/ruby_tracklib/irbrc.rb
@@ -1,0 +1,8 @@
+if ENV["INSIDE_EMACS"] then
+   IRB.conf[:USE_MULTILINE] = nil
+   IRB.conf[:USE_SINGLELINE] = false
+   IRB.conf[:PROMPT_MODE] = :INF_RUBY
+
+   IRB.conf[:USE_READLINE] = false
+   IRB.conf[:USE_COLORIZE] = true
+end

--- a/ruby_tracklib/spec/roundtrip_spec.rb
+++ b/ruby_tracklib/spec/roundtrip_spec.rb
@@ -16,12 +16,19 @@ describe Tracklib do
   end
 
   it "can roundtrip an F64 column" do
+    scale = 7
+    i64_max = 2 ** 63
+    schema_max = i64_max / 10 ** scale
+
     data = [{"a" => 0},
             {},
             {"a" => 11.2},
-            {"a" => -400.000003}]
+            {"a" => -400.000003},
+            {"a" => -schema_max},
+            {"a" => schema_max},
+            {"a" => 50.1234567}]
 
-    schema = Tracklib::Schema.new([["a", :f64, 7]])
+    schema = Tracklib::Schema.new([["a", :f64, scale]])
     section = Tracklib::Section::standard(schema, data)
     buf = Tracklib::write_track([], [section])
     reader = Tracklib::TrackReader::new(buf)

--- a/ruby_tracklib/tracklib.gemspec
+++ b/ruby_tracklib/tracklib.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.extensions = ["Rakefile"]
 
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rake"
 
   spec.add_dependency 'rutie', '~> 0.0.4'
 end

--- a/rwtfinspect/Cargo.lock
+++ b/rwtfinspect/Cargo.lock
@@ -252,7 +252,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "flate2",
- "tracklib2",
+ "tracklib",
 ]
 
 [[package]]
@@ -315,8 +315,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracklib2"
-version = "0.1.0"
+name = "tracklib"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "crc",

--- a/rwtfinspect/Cargo.toml
+++ b/rwtfinspect/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 [dependencies]
 base64 = "0.13"
 flate2 = "1.0"
-tracklib2 = {path = "../tracklib2", features=["inspect"]}
+tracklib = {path = "../tracklib", features=["inspect"]}

--- a/rwtfinspect/src/main.rs
+++ b/rwtfinspect/src/main.rs
@@ -1,5 +1,5 @@
 use std::io::Read;
-use tracklib2::read::inspect::inspect;
+use tracklib::read::inspect::inspect;
 
 const USAGE: &'static str = "usage: rwtfinspect <filename> <base64 password>";
 

--- a/tracklib/src/error.rs
+++ b/tracklib/src/error.rs
@@ -14,6 +14,9 @@ pub enum TracklibError {
     #[error("CRC Error")]
     CRC32Error { expected: u32, computed: u32 },
 
+    #[error("Encoding Bounds Error")]
+    EncodingBoundsError,
+
     #[error("Numeric Bounds Error")]
     BoundsError {
         #[from]

--- a/tracklib/src/read/bitstream.rs
+++ b/tracklib/src/read/bitstream.rs
@@ -4,7 +4,7 @@ use nom_leb128::{leb128_i64, leb128_u64};
 
 pub fn read_i64<'a>(data: &'a [u8], prev: &mut i64) -> Result<(&'a [u8], i64)> {
     let (rest, value) = leb128_i64(data)?;
-    let new = *prev + value;
+    let new = prev.wrapping_add(value);
     *prev = new;
     Ok((rest, new))
 }

--- a/tracklib/src/types.rs
+++ b/tracklib/src/types.rs
@@ -10,6 +10,72 @@ pub enum FieldValue {
     ByteArray(Vec<u8>),
 }
 
+impl FieldValue {
+    pub fn into_i64(self) -> Option<i64> {
+        if let Self::I64(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn into_u64(self) -> Option<u64> {
+        if let Self::U64(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn into_f64(self) -> Option<f64> {
+        if let Self::F64(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn into_bool(self) -> Option<bool> {
+        if let Self::Bool(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn into_string(self) -> Option<String> {
+        if let Self::String(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn into_bool_array(self) -> Option<Vec<bool>> {
+        if let Self::BoolArray(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn into_u64_array(self) -> Option<Vec<u64>> {
+        if let Self::U64Array(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn into_byte_array(self) -> Option<Vec<u8>> {
+        if let Self::ByteArray(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub enum TrackType {
     Trip(u64),

--- a/tracklib/src/write/bitstream.rs
+++ b/tracklib/src/write/bitstream.rs
@@ -7,7 +7,7 @@ where
 {
     if let Some(val) = value {
         let v = *val;
-        let delta = v - *prev;
+        let delta = v.wrapping_sub(*prev);
         leb128::write::signed(buf, delta)?;
         *prev = v;
     }

--- a/tracklib/src/write/bitstream.rs
+++ b/tracklib/src/write/bitstream.rs
@@ -15,13 +15,11 @@ where
     Ok(())
 }
 
-pub fn write_byte<W>(value: Option<&u8>, buf: &mut W) -> Result<()>
+pub fn write_byte<W>(value: u8, buf: &mut W) -> Result<()>
 where
     W: ?Sized + Write,
 {
-    if let Some(val) = value {
-        buf.write_all(std::slice::from_ref(val))?;
-    }
+    buf.write_all(std::slice::from_ref(&value))?;
     Ok(())
 }
 
@@ -57,10 +55,9 @@ mod tests {
     #[test]
     fn test_write_byte() {
         let mut buf = vec![];
-        assert_matches!(write_byte(Some(&0), &mut buf), Ok(()));
-        assert_matches!(write_byte(None, &mut buf), Ok(()));
-        assert_matches!(write_byte(Some(&1), &mut buf), Ok(()));
-        assert_matches!(write_byte(Some(&255), &mut buf), Ok(()));
+        assert_matches!(write_byte(0, &mut buf), Ok(()));
+        assert_matches!(write_byte(1, &mut buf), Ok(()));
+        assert_matches!(write_byte(255, &mut buf), Ok(()));
         #[rustfmt::skip]
         assert_eq!(buf, &[0x00,
                           0x01,

--- a/tracklib/src/write/bitstream.rs
+++ b/tracklib/src/write/bitstream.rs
@@ -1,16 +1,13 @@
 use crate::error::Result;
 use std::io::Write;
 
-pub fn write_i64<W>(value: Option<&i64>, buf: &mut W, prev: &mut i64) -> Result<()>
+pub fn write_i64<W>(value: i64, buf: &mut W, prev: &mut i64) -> Result<()>
 where
     W: ?Sized + Write,
 {
-    if let Some(val) = value {
-        let v = *val;
-        let delta = v.wrapping_sub(*prev);
-        leb128::write::signed(buf, delta)?;
-        *prev = v;
-    }
+    let delta = value.wrapping_sub(*prev);
+    leb128::write::signed(buf, delta)?;
+    *prev = value;
 
     Ok(())
 }
@@ -44,9 +41,8 @@ mod tests {
     fn test_write_i64() {
         let mut buf = vec![];
         let mut prev = 0;
-        assert_matches!(write_i64(Some(&0), &mut buf, &mut prev), Ok(()));
-        assert_matches!(write_i64(None, &mut buf, &mut prev), Ok(()));
-        assert_matches!(write_i64(Some(&42), &mut buf, &mut prev), Ok(()));
+        assert_matches!(write_i64(0, &mut buf, &mut prev), Ok(()));
+        assert_matches!(write_i64(42, &mut buf, &mut prev), Ok(()));
         #[rustfmt::skip]
         assert_eq!(buf, &[0x00,
                           0x2A]);

--- a/tracklib/src/write/bitstream.rs
+++ b/tracklib/src/write/bitstream.rs
@@ -1,25 +1,34 @@
 use crate::error::Result;
 use std::io::Write;
 
-pub fn write_i64(value: Option<&i64>, buf: &mut Vec<u8>, prev: &mut i64) -> Result<()> {
+pub fn write_i64<W>(value: Option<&i64>, buf: &mut W, prev: &mut i64) -> Result<()>
+where
+    W: ?Sized + Write,
+{
     if let Some(val) = value {
         let v = *val;
         let delta = v - *prev;
-        *prev = v;
         leb128::write::signed(buf, delta)?;
+        *prev = v;
     }
 
     Ok(())
 }
 
-pub fn write_byte(value: Option<&u8>, buf: &mut Vec<u8>) -> Result<()> {
+pub fn write_byte<W>(value: Option<&u8>, buf: &mut W) -> Result<()>
+where
+    W: ?Sized + Write,
+{
     if let Some(val) = value {
         buf.write_all(std::slice::from_ref(val))?;
     }
     Ok(())
 }
 
-pub fn write_bytes(value: Option<&[u8]>, buf: &mut Vec<u8>) -> Result<()> {
+pub fn write_bytes<W>(value: Option<&[u8]>, buf: &mut W) -> Result<()>
+where
+    W: ?Sized + Write,
+{
     if let Some(val) = value {
         // Write len
         leb128::write::unsigned(buf, u64::try_from(val.len()).expect("usize != u64"))?;

--- a/tracklib/src/write/bitstream.rs
+++ b/tracklib/src/write/bitstream.rs
@@ -25,16 +25,14 @@ where
     Ok(())
 }
 
-pub fn write_bytes<W>(value: Option<&[u8]>, buf: &mut W) -> Result<()>
+pub fn write_bytes<W>(value: &[u8], buf: &mut W) -> Result<()>
 where
     W: ?Sized + Write,
 {
-    if let Some(val) = value {
-        // Write len
-        leb128::write::unsigned(buf, u64::try_from(val.len()).expect("usize != u64"))?;
-        // Write bytes
-        buf.write_all(val)?;
-    }
+    // Write len
+    leb128::write::unsigned(buf, u64::try_from(value.len()).expect("usize != u64"))?;
+    // Write bytes
+    buf.write_all(value)?;
 
     Ok(())
 }
@@ -72,9 +70,8 @@ mod tests {
     #[test]
     fn test_write_bytes() {
         let mut buf = vec![];
-        assert_matches!(write_bytes(Some(&[b'R', b'W']), &mut buf), Ok(()));
-        assert_matches!(write_bytes(None, &mut buf), Ok(()));
-        assert_matches!(write_bytes(Some(&[b'G', b'P', b'S']), &mut buf), Ok(()));
+        assert_matches!(write_bytes(&[b'R', b'W'], &mut buf), Ok(()));
+        assert_matches!(write_bytes(&[b'G', b'P', b'S'], &mut buf), Ok(()));
         #[rustfmt::skip]
         assert_eq!(buf, &[0x02,
                           b'R',

--- a/tracklib/src/write/encoders.rs
+++ b/tracklib/src/write/encoders.rs
@@ -3,7 +3,9 @@ use crate::error::Result;
 
 pub trait Encoder {
     type T: ?Sized;
-    fn encode(&mut self, value: Option<&Self::T>, buf: &mut Vec<u8>, presence: &mut Vec<bool>) -> Result<()>;
+    fn encode<W>(&mut self, value: Option<&Self::T>, buf: &mut W, presence: &mut Vec<bool>) -> Result<()>
+    where
+        W: ?Sized + std::io::Write;
 }
 
 #[derive(Debug, Default)]
@@ -14,9 +16,11 @@ pub struct I64Encoder {
 impl Encoder for I64Encoder {
     type T = i64;
 
-    fn encode(&mut self, value: Option<&Self::T>, buf: &mut Vec<u8>, presence: &mut Vec<bool>) -> Result<()> {
-        presence.push(value.is_some());
-        bitstream::write_i64(value, buf, &mut self.prev)
+    fn encode<W>(&mut self, value: Option<&Self::T>, buf: &mut W, presence: &mut Vec<bool>) -> Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        bitstream::write_i64(value, buf, &mut self.prev).map(|_| presence.push(value.is_some()))
     }
 }
 
@@ -28,9 +32,12 @@ pub struct U64Encoder {
 impl Encoder for U64Encoder {
     type T = u64;
 
-    fn encode(&mut self, value: Option<&Self::T>, buf: &mut Vec<u8>, presence: &mut Vec<bool>) -> Result<()> {
-        presence.push(value.is_some());
+    fn encode<W>(&mut self, value: Option<&Self::T>, buf: &mut W, presence: &mut Vec<bool>) -> Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
         bitstream::write_i64(value.map(|val| *val as i64).as_ref(), buf, &mut self.prev)
+            .map(|_| presence.push(value.is_some()))
     }
 }
 
@@ -52,13 +59,16 @@ impl F64Encoder {
 impl Encoder for F64Encoder {
     type T = f64;
 
-    fn encode(&mut self, value: Option<&Self::T>, buf: &mut Vec<u8>, presence: &mut Vec<bool>) -> Result<()> {
-        presence.push(value.is_some());
+    fn encode<W>(&mut self, value: Option<&Self::T>, buf: &mut W, presence: &mut Vec<bool>) -> Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
         bitstream::write_i64(
             value.map(|val| (*val * self.factor) as i64).as_ref(),
             buf,
             &mut self.prev,
         )
+        .map(|_| presence.push(value.is_some()))
     }
 }
 
@@ -68,9 +78,11 @@ pub struct BoolEncoder;
 impl Encoder for BoolEncoder {
     type T = bool;
 
-    fn encode(&mut self, value: Option<&Self::T>, buf: &mut Vec<u8>, presence: &mut Vec<bool>) -> Result<()> {
-        presence.push(value.is_some());
-        bitstream::write_byte(value.map(|v| u8::from(*v)).as_ref(), buf)
+    fn encode<W>(&mut self, value: Option<&Self::T>, buf: &mut W, presence: &mut Vec<bool>) -> Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        bitstream::write_byte(value.map(|v| u8::from(*v)).as_ref(), buf).map(|_| presence.push(value.is_some()))
     }
 }
 
@@ -80,9 +92,11 @@ pub struct StringEncoder;
 impl Encoder for StringEncoder {
     type T = str;
 
-    fn encode(&mut self, value: Option<&Self::T>, buf: &mut Vec<u8>, presence: &mut Vec<bool>) -> Result<()> {
-        presence.push(value.is_some());
-        bitstream::write_bytes(value.map(|v| v.as_bytes()), buf)
+    fn encode<W>(&mut self, value: Option<&Self::T>, buf: &mut W, presence: &mut Vec<bool>) -> Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        bitstream::write_bytes(value.map(|v| v.as_bytes()), buf).map(|_| presence.push(value.is_some()))
     }
 }
 
@@ -92,14 +106,17 @@ pub struct BoolArrayEncoder;
 impl Encoder for BoolArrayEncoder {
     type T = [bool];
 
-    fn encode(&mut self, value: Option<&Self::T>, buf: &mut Vec<u8>, presence: &mut Vec<bool>) -> Result<()> {
-        presence.push(value.is_some());
+    fn encode<W>(&mut self, value: Option<&Self::T>, buf: &mut W, presence: &mut Vec<bool>) -> Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
         if let Some(array) = value {
             leb128::write::unsigned(buf, u64::try_from(array.len()).expect("usize != u64"))?;
             for b in array {
                 bitstream::write_byte(Some(u8::from(*b)).as_ref(), buf)?;
             }
         }
+        presence.push(value.is_some());
         Ok(())
     }
 }
@@ -110,8 +127,10 @@ pub struct U64ArrayEncoder;
 impl Encoder for U64ArrayEncoder {
     type T = [u64];
 
-    fn encode(&mut self, value: Option<&Self::T>, buf: &mut Vec<u8>, presence: &mut Vec<bool>) -> Result<()> {
-        presence.push(value.is_some());
+    fn encode<W>(&mut self, value: Option<&Self::T>, buf: &mut W, presence: &mut Vec<bool>) -> Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
         if let Some(array) = value {
             leb128::write::unsigned(buf, u64::try_from(array.len()).expect("usize != u64"))?;
 
@@ -120,6 +139,7 @@ impl Encoder for U64ArrayEncoder {
                 bitstream::write_i64(Some(*val as i64).as_ref(), buf, &mut prev)?;
             }
         }
+        presence.push(value.is_some());
         Ok(())
     }
 }
@@ -130,14 +150,17 @@ pub struct ByteArrayEncoder;
 impl Encoder for ByteArrayEncoder {
     type T = [u8];
 
-    fn encode(&mut self, value: Option<&Self::T>, buf: &mut Vec<u8>, presence: &mut Vec<bool>) -> Result<()> {
-        presence.push(value.is_some());
+    fn encode<W>(&mut self, value: Option<&Self::T>, buf: &mut W, presence: &mut Vec<bool>) -> Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
         if let Some(array) = value {
             leb128::write::unsigned(buf, u64::try_from(array.len()).expect("usize != u64"))?;
             for b in array {
                 bitstream::write_byte(Some(b), buf)?;
             }
         }
+        presence.push(value.is_some());
         Ok(())
     }
 }
@@ -145,16 +168,19 @@ impl Encoder for ByteArrayEncoder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::write::util::LimitedWriteWrapper;
 
     #[test]
     fn test_i64_encoder() {
-        let mut data_buf = vec![];
+        let mut data_buf = LimitedWriteWrapper::new(vec![], 3);
         let mut presence_buf = vec![];
         let mut encoder = I64Encoder::default();
 
         assert!(encoder.encode(Some(&1), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(Some(&2), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(Some(&3), &mut data_buf, &mut presence_buf).is_ok());
+        assert!(encoder.encode(Some(&-100), &mut data_buf, &mut presence_buf).is_err());
+        data_buf.expand(100);
         assert!(encoder.encode(Some(&-100), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(None, &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(None, &mut data_buf, &mut presence_buf).is_ok());
@@ -162,37 +188,41 @@ mod tests {
         assert!(encoder.encode(Some(&100), &mut data_buf, &mut presence_buf).is_ok());
 
         #[rustfmt::skip]
-        assert_eq!(data_buf, &[0x01, // +1 from 0
-                               0x01, // +1 from 1
-                               0x01, // +1 from 2
-                               0x99, // -103 from 3
-                               0x7F,
-                               // None
-                               // None
-                               0x00, // staying at -100
-                               0xC8, // +200 from -100
-                               0x01]);
+        assert_eq!(data_buf.into_inner(),
+                   &[0x01, // +1 from 0
+                     0x01, // +1 from 1
+                     0x01, // +1 from 2
+                     0x99, // -103 from 3
+                     0x7F,
+                     // None
+                     // None
+                     0x00, // staying at -100
+                     0xC8, // +200 from -100
+                     0x01]);
 
         #[rustfmt::skip]
-        assert_eq!(presence_buf, &[true,
-                                   true,
-                                   true,
-                                   true,
-                                   false,
-                                   false,
-                                   true,
-                                   true]);
+        assert_eq!(presence_buf,
+                   &[true,
+                     true,
+                     true,
+                     true,
+                     false,
+                     false,
+                     true,
+                     true]);
     }
 
     #[test]
     fn test_u64_encoder() {
-        let mut data_buf = vec![];
+        let mut data_buf = LimitedWriteWrapper::new(vec![], 2);
         let mut presence_buf = vec![];
         let mut encoder = U64Encoder::default();
 
         assert!(encoder.encode(Some(&1), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(Some(&2), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(None, &mut data_buf, &mut presence_buf).is_ok());
+        assert!(encoder.encode(Some(&100), &mut data_buf, &mut presence_buf).is_err());
+        data_buf.expand(100);
         assert!(encoder.encode(Some(&100), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder
             .encode(Some(&u64::MAX), &mut data_buf, &mut presence_buf)
@@ -200,136 +230,151 @@ mod tests {
         assert!(encoder.encode(Some(&7), &mut data_buf, &mut presence_buf).is_ok());
 
         #[rustfmt::skip]
-        assert_eq!(data_buf, &[0x01,
-                               0x01,
-                               0xE2,
-                               0x00,
-                               0x9B,
-                               0x7F,
-                               0x08]);
+        assert_eq!(data_buf.into_inner(),
+                   &[0x01,
+                     0x01,
+                     0xE2,
+                     0x00,
+                     0x9B,
+                     0x7F,
+                     0x08]);
 
         #[rustfmt::skip]
-        assert_eq!(presence_buf, &[true,
-                                   true,
-                                   false,
-                                   true,
-                                   true,
-                                   true]);
+        assert_eq!(presence_buf,
+                   &[true,
+                     true,
+                     false,
+                     true,
+                     true,
+                     true]);
     }
 
     #[test]
-    fn test_f64_encoder() {
-        let mut data_buf = vec![];
+    fn test_f64_encoder_scale_7() {
+        let mut data_buf = LimitedWriteWrapper::new(vec![], 5);
         let mut presence_buf = vec![];
         let mut encoder = F64Encoder::new(7);
 
         assert!(encoder.encode(Some(&0.0), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(Some(&1.0), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(None, &mut data_buf, &mut presence_buf).is_ok());
+        assert!(encoder.encode(Some(&2.5), &mut data_buf, &mut presence_buf).is_err());
+        data_buf.expand(100);
         assert!(encoder.encode(Some(&2.5), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(Some(&3.00001), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(Some(&-100.26), &mut data_buf, &mut presence_buf).is_ok());
 
         #[rustfmt::skip]
-        assert_eq!(data_buf, &[0x00, // first storing a 0
+        assert_eq!(data_buf.into_inner(),
+                   &[0x00, // first storing a 0
 
-                               0x80, // leb128-encoded difference between prev (0.0) and 1.0 * 10e6
-                               0xAD,
-                               0xE2,
-                               0x04,
+                     0x80, // leb128-encoded difference between prev (0.0) and 1.0 * 10e6
+                     0xAD,
+                     0xE2,
+                     0x04,
 
-                               // None
+                     // None
 
-                               0xC0, // leb128-encoded delta between prev and 2.5 * 10e6
-                               0xC3,
-                               0x93,
-                               0x07,
+                     0xC0, // leb128-encoded delta between prev and 2.5 * 10e6
+                     0xC3,
+                     0x93,
+                     0x07,
 
-                               0xA4, // leb128-encoded delta between prev and 3.00001 * 10e6
-                               0x97,
-                               0xB1,
-                               0x02,
+                     0xA4, // leb128-encoded delta between prev and 3.00001 * 10e6
+                     0x97,
+                     0xB1,
+                     0x02,
 
-                               0xDC, // leb128-encoded delta between prev and -100.26 * 10e6
-                               0x8B,
-                               0xCF,
-                               0x93,
-                               0x7C]);
+                     0xDC, // leb128-encoded delta between prev and -100.26 * 10e6
+                     0x8B,
+                     0xCF,
+                     0x93,
+                     0x7C]);
 
         #[rustfmt::skip]
-        assert_eq!(presence_buf, &[true,
-                                   true,
-                                   false,
-                                   true,
-                                   true,
-                                   true]);
+        assert_eq!(presence_buf,
+                   &[true,
+                     true,
+                     false,
+                     true,
+                     true,
+                     true]);
     }
 
     #[test]
-    fn test_f64_encoder_smaller_scale_factor() {
-        let mut data_buf = vec![];
+    fn test_f64_encoder_scale_2() {
+        let mut data_buf = LimitedWriteWrapper::new(vec![], 3);
         let mut presence_buf = vec![];
         let mut encoder = F64Encoder::new(2);
 
         assert!(encoder.encode(Some(&0.0), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(Some(&1.0), &mut data_buf, &mut presence_buf).is_ok());
+        assert!(encoder.encode(Some(&-20.0), &mut data_buf, &mut presence_buf).is_err());
+        data_buf.expand(100);
         assert!(encoder.encode(Some(&-20.0), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder
             .encode(Some(&-20.1234567), &mut data_buf, &mut presence_buf)
             .is_ok());
 
         #[rustfmt::skip]
-        assert_eq!(data_buf, &[0x00,
-                               0xE4,
-                               0x00,
-                               0xCC,
-                               0x6F,
-                               0x74,
-        ]);
+        assert_eq!(data_buf.into_inner(),
+                   &[0x00,
+                     0xE4,
+                     0x00,
+                     0xCC,
+                     0x6F,
+                     0x74]);
 
         #[rustfmt::skip]
-        assert_eq!(presence_buf, &[true,
-                                   true,
-                                   true,
-                                   true]);
+        assert_eq!(presence_buf,
+                   &[true,
+                     true,
+                     true,
+                     true]);
     }
 
     #[test]
     fn test_bool_encoder() {
-        let mut data_buf = vec![];
+        let mut data_buf = LimitedWriteWrapper::new(vec![], 2);
         let mut presence_buf = vec![];
         let mut encoder = BoolEncoder::default();
 
         assert!(encoder.encode(Some(&true), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(Some(&true), &mut data_buf, &mut presence_buf).is_ok());
+        assert!(encoder.encode(Some(&false), &mut data_buf, &mut presence_buf).is_err());
+        data_buf.expand(1);
         assert!(encoder.encode(Some(&false), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(None, &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(None, &mut data_buf, &mut presence_buf).is_ok());
+        assert!(encoder.encode(Some(&false), &mut data_buf, &mut presence_buf).is_err());
+        data_buf.expand(2);
         assert!(encoder.encode(Some(&false), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(Some(&true), &mut data_buf, &mut presence_buf).is_ok());
 
         #[rustfmt::skip]
-        assert_eq!(data_buf, &[0x01,   // true
-                               0x01,   // true
-                               0x00,   // false
-                               // None
-                               // None
-                               0x00,   // false
-                               0x01]); // true
+        assert_eq!(data_buf.into_inner(),
+                   &[0x01,   // true
+                     0x01,   // true
+                     0x00,   // false
+                     // None
+                     // None
+                     0x00,   // false
+                     0x01]); // true
 
         #[rustfmt::skip]
-        assert_eq!(presence_buf, &[true,
-                                   true,
-                                   true,
-                                   false,
-                                   false,
-                                   true,
-                                   true]);
+        assert_eq!(presence_buf,
+                   &[true,
+                     true,
+                     true,
+                     false,
+                     false,
+                     true,
+                     true]);
     }
 
     #[test]
     fn test_string_encoder() {
-        let mut data_buf = vec![];
+        let mut data_buf = LimitedWriteWrapper::new(vec![], 4);
         let mut presence_buf = vec![];
         let mut encoder = StringEncoder::default();
 
@@ -337,6 +382,8 @@ mod tests {
         assert!(encoder.encode(None, &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(Some("B"), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(None, &mut data_buf, &mut presence_buf).is_ok());
+        assert!(encoder.encode(Some("C"), &mut data_buf, &mut presence_buf).is_err());
+        data_buf.expand(100);
         assert!(encoder.encode(Some("C"), &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder.encode(None, &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder
@@ -345,46 +392,48 @@ mod tests {
         assert!(encoder.encode(None, &mut data_buf, &mut presence_buf).is_ok());
 
         #[rustfmt::skip]
-        assert_eq!(data_buf, &[0x01, // length
-                               b'A', // A
-                               // None
-                               0x01, // length
-                               b'B', // B
-                               // None
-                               0x01, // length
-                               b'C', // C
-                               // None
-                               0x0D, // length
-                               b'H',
-                               b'e',
-                               b'l',
-                               b'l',
-                               b'o',
-                               b',',
-                               b' ',
-                               b'W',
-                               b'o',
-                               b'r',
-                               b'l',
-                               b'd',
-                               b'!'
-                               // None
-        ]);
+        assert_eq!(data_buf.into_inner(),
+                   &[0x01, // length
+                     b'A', // A
+                     // None
+                     0x01, // length
+                     b'B', // B
+                     // None
+                     0x01, // length
+                     b'C', // C
+                     // None
+                     0x0D, // length
+                     b'H',
+                     b'e',
+                     b'l',
+                     b'l',
+                     b'o',
+                     b',',
+                     b' ',
+                     b'W',
+                     b'o',
+                     b'r',
+                     b'l',
+                     b'd',
+                     b'!'
+                     // None
+                   ]);
 
         #[rustfmt::skip]
-        assert_eq!(presence_buf, &[true,
-                                   false,
-                                   true,
-                                   false,
-                                   true,
-                                   false,
-                                   true,
-                                   false]);
+        assert_eq!(presence_buf,
+                   &[true,
+                     false,
+                     true,
+                     false,
+                     true,
+                     false,
+                     true,
+                     false]);
     }
 
     #[test]
     fn test_bool_array_encoder() {
-        let mut data_buf = vec![];
+        let mut data_buf = LimitedWriteWrapper::new(vec![], 4);
         let mut presence_buf = vec![];
         let mut encoder = BoolArrayEncoder::default();
 
@@ -392,6 +441,8 @@ mod tests {
             .encode(Some(&[true, false, false]), &mut data_buf, &mut presence_buf)
             .is_ok());
         assert!(encoder.encode(None, &mut data_buf, &mut presence_buf).is_ok());
+        assert!(encoder.encode(Some(&[]), &mut data_buf, &mut presence_buf).is_err());
+        data_buf.expand(100);
         assert!(encoder
             .encode(
                 Some(&[false, false, false, false, true, true]),
@@ -402,36 +453,40 @@ mod tests {
         assert!(encoder.encode(Some(&[true]), &mut data_buf, &mut presence_buf).is_ok());
 
         #[rustfmt::skip]
-        assert_eq!(data_buf, &[0x03, // array len three
-                               0x01, // true
-                               0x00, // false
-                               0x00, // false
-                               0x06, // array len six
-                               0x00, // false
-                               0x00, // false
-                               0x00, // false
-                               0x00, // false
-                               0x01, // true
-                               0x01, // true
-                               0x01, // array len one
-                               0x01]); // true
+        assert_eq!(data_buf.into_inner(),
+                   &[0x03, // array len three
+                     0x01, // true
+                     0x00, // false
+                     0x00, // false
+                     0x06, // array len six
+                     0x00, // false
+                     0x00, // false
+                     0x00, // false
+                     0x00, // false
+                     0x01, // true
+                     0x01, // true
+                     0x01, // array len one
+                     0x01]); // true
 
         #[rustfmt::skip]
-        assert_eq!(presence_buf, &[true,
-                                   false,
-                                   true,
-                                   true]);
+        assert_eq!(presence_buf,
+                   &[true,
+                     false,
+                     true,
+                     true]);
     }
 
     #[test]
     fn test_u64_array_encoder() {
-        let mut data_buf = vec![];
+        let mut data_buf = LimitedWriteWrapper::new(vec![], 4);
         let mut presence_buf = vec![];
         let mut encoder = U64ArrayEncoder::default();
 
         assert!(encoder
             .encode(Some(&[0, 17, 15]), &mut data_buf, &mut presence_buf)
             .is_ok());
+        assert!(encoder.encode(Some(&[0]), &mut data_buf, &mut presence_buf).is_err());
+        data_buf.expand(100);
         assert!(encoder.encode(None, &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder
             .encode(Some(&[8_000, 1]), &mut data_buf, &mut presence_buf)
@@ -439,35 +494,39 @@ mod tests {
         assert!(encoder.encode(Some(&[50]), &mut data_buf, &mut presence_buf).is_ok());
 
         #[rustfmt::skip]
-        assert_eq!(data_buf, &[0x03, // array len three
-                               0x00, // zero
-                               0x11, // 17
-                               0x7E, // -2
-                               0x02, // array len 2
-                               0xC0, // 8,000
-                               0x3E,
-                               0xC1, // -7,999
-                               0x41,
-                               0x01, // array len 1
-                               0x32, // 50
-        ]);
+        assert_eq!(data_buf.into_inner(),
+                   &[0x03, // array len three
+                     0x00, // zero
+                     0x11, // 17
+                     0x7E, // -2
+                     0x02, // array len 2
+                     0xC0, // 8,000
+                     0x3E,
+                     0xC1, // -7,999
+                     0x41,
+                     0x01, // array len 1
+                     0x32, // 50
+                   ]);
 
         #[rustfmt::skip]
-        assert_eq!(presence_buf, &[true,
-                                   false,
-                                   true,
-                                   true]);
+        assert_eq!(presence_buf,
+                   &[true,
+                     false,
+                     true,
+                     true]);
     }
 
     #[test]
     fn test_byte_array_encoder() {
-        let mut data_buf = vec![];
+        let mut data_buf = LimitedWriteWrapper::new(vec![], 4);
         let mut presence_buf = vec![];
         let mut encoder = ByteArrayEncoder::default();
 
         assert!(encoder
             .encode(Some(&[0, 17, 15]), &mut data_buf, &mut presence_buf)
             .is_ok());
+        assert!(encoder.encode(Some(&[0]), &mut data_buf, &mut presence_buf).is_err());
+        data_buf.expand(100);
         assert!(encoder.encode(None, &mut data_buf, &mut presence_buf).is_ok());
         assert!(encoder
             .encode(Some(&[255, 1]), &mut data_buf, &mut presence_buf)
@@ -475,21 +534,23 @@ mod tests {
         assert!(encoder.encode(Some(&[127]), &mut data_buf, &mut presence_buf).is_ok());
 
         #[rustfmt::skip]
-        assert_eq!(data_buf, &[0x03, // array len three
-                               0x00, // zero
-                               0x11, // 17
-                               0x0F, // 15
-                               0x02, // array len 2
-                               0xFF, // 255
-                               0x01, // 1
-                               0x01, // array len 1
-                               0x7F, // 127
-        ]);
+        assert_eq!(data_buf.into_inner(),
+                   &[0x03, // array len three
+                     0x00, // zero
+                     0x11, // 17
+                     0x0F, // 15
+                     0x02, // array len 2
+                     0xFF, // 255
+                     0x01, // 1
+                     0x01, // array len 1
+                     0x7F, // 127
+                   ]);
 
         #[rustfmt::skip]
-        assert_eq!(presence_buf, &[true,
-                                   false,
-                                   true,
-                                   true]);
+        assert_eq!(presence_buf,
+                   &[true,
+                     false,
+                     true,
+                     true]);
     }
 }

--- a/tracklib/src/write/encoders.rs
+++ b/tracklib/src/write/encoders.rs
@@ -20,7 +20,10 @@ impl Encoder for I64Encoder {
     where
         W: ?Sized + std::io::Write,
     {
-        bitstream::write_i64(value, buf, &mut self.prev).map(|_| presence.push(value.is_some()))
+        value
+            .map(|val| bitstream::write_i64(*val, buf, &mut self.prev))
+            .transpose()
+            .map(|v| presence.push(v.is_some()))
     }
 }
 
@@ -36,8 +39,10 @@ impl Encoder for U64Encoder {
     where
         W: ?Sized + std::io::Write,
     {
-        bitstream::write_i64(value.map(|val| *val as i64).as_ref(), buf, &mut self.prev)
-            .map(|_| presence.push(value.is_some()))
+        value
+            .map(|val| bitstream::write_i64(*val as i64, buf, &mut self.prev))
+            .transpose()
+            .map(|v| presence.push(v.is_some()))
     }
 }
 
@@ -142,7 +147,7 @@ impl Encoder for U64ArrayEncoder {
 
             let mut prev = 0;
             for val in array {
-                bitstream::write_i64(Some(*val as i64).as_ref(), buf, &mut prev)?;
+                bitstream::write_i64(*val as i64, buf, &mut prev)?;
             }
         }
         presence.push(value.is_some());

--- a/tracklib/src/write/encoders.rs
+++ b/tracklib/src/write/encoders.rs
@@ -82,7 +82,10 @@ impl Encoder for BoolEncoder {
     where
         W: ?Sized + std::io::Write,
     {
-        bitstream::write_byte(value.map(|v| u8::from(*v)).as_ref(), buf).map(|_| presence.push(value.is_some()))
+        value
+            .map(|val| bitstream::write_byte(u8::from(*val), buf))
+            .transpose()
+            .map(|v| presence.push(v.is_some()))
     }
 }
 
@@ -116,7 +119,7 @@ impl Encoder for BoolArrayEncoder {
         if let Some(array) = value {
             leb128::write::unsigned(buf, u64::try_from(array.len()).expect("usize != u64"))?;
             for b in array {
-                bitstream::write_byte(Some(u8::from(*b)).as_ref(), buf)?;
+                bitstream::write_byte(u8::from(*b), buf)?;
             }
         }
         presence.push(value.is_some());
@@ -160,7 +163,7 @@ impl Encoder for ByteArrayEncoder {
         if let Some(array) = value {
             leb128::write::unsigned(buf, u64::try_from(array.len()).expect("usize != u64"))?;
             for b in array {
-                bitstream::write_byte(Some(b), buf)?;
+                bitstream::write_byte(*b, buf)?;
             }
         }
         presence.push(value.is_some());

--- a/tracklib/src/write/encoders.rs
+++ b/tracklib/src/write/encoders.rs
@@ -96,7 +96,10 @@ impl Encoder for StringEncoder {
     where
         W: ?Sized + std::io::Write,
     {
-        bitstream::write_bytes(value.map(|v| v.as_bytes()), buf).map(|_| presence.push(value.is_some()))
+        value
+            .map(|val| bitstream::write_bytes(val.as_bytes(), buf))
+            .transpose()
+            .map(|v| presence.push(v.is_some()))
     }
 }
 

--- a/tracklib/src/write/mod.rs
+++ b/tracklib/src/write/mod.rs
@@ -6,3 +6,5 @@ mod header;
 pub mod metadata;
 pub mod section;
 pub mod track;
+#[cfg(test)]
+pub(self) mod util;

--- a/tracklib/src/write/util.rs
+++ b/tracklib/src/write/util.rs
@@ -1,0 +1,41 @@
+use std::io::Write;
+
+#[derive(Debug)]
+pub(crate) struct LimitedWriteWrapper<T> {
+    buf: T,
+    limit: usize,
+}
+
+impl<T> LimitedWriteWrapper<T> {
+    pub(crate) fn new(buf: T, limit: usize) -> Self {
+        Self { buf, limit }
+    }
+    pub(crate) fn expand(&mut self, new_limit: usize) {
+        self.limit = new_limit;
+    }
+
+    pub(crate) fn into_inner(self) -> T {
+        self.buf
+    }
+}
+
+impl<T: Write> Write for LimitedWriteWrapper<T> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if buf.len() > self.limit {
+            Err(std::io::Error::new(std::io::ErrorKind::OutOfMemory, "buffer is full"))
+        } else {
+            let len = buf.len();
+            match self.buf.write_all(buf) {
+                Ok(_) => {
+                    self.limit -= len;
+                    Ok(len)
+                }
+                Err(e) => Err(e),
+            }
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.buf.flush()
+    }
+}

--- a/tracklib/tests/roundtrip.rs
+++ b/tracklib/tests/roundtrip.rs
@@ -1,5 +1,3 @@
-// Only run these tests in a release build because they rely on unchecked math
-#[cfg(not(debug_assertions))]
 mod tests {
     use std::collections::HashMap;
     use tracklib::read::track::TrackReader;


### PR DESCRIPTION
* Fix a bug where a failed write (to memory) could cause corruption
* Fix a bug where writing a very large f64 could cause the wrong number to be stored, now that will return an error
* Fix rwtfinspect dependency path
* Add new methods to FieldValue
* misc